### PR TITLE
Fix recursive dictionary merging in map.jinja

### DIFF
--- a/packer/defaults.yml
+++ b/packer/defaults.yml
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # vim: ft=yaml
-packer:
+default:
   download:
     url:  https://releases.hashicorp.com/packer/VERSION/packer_VERSION_linux_amd64.zip
     hash: 'sha256=7d51fc5db19d02bbf32278a8116830fae33a3f9bd4440a58d23ad7c863e92e28'
@@ -8,3 +8,7 @@ packer:
   path:
     extract_to: /opt/packer/VERSION
     profile: /etc/profile.d/packer.sh 
+#Debian:
+#Suse:
+#Arch:
+#RedHat

--- a/packer/map.jinja
+++ b/packer/map.jinja
@@ -1,29 +1,18 @@
 # -*- coding: utf-8 -*-
 # vim: ft=jinja
 
-{## Start with  defaults from defaults.sls ##}
+{## Start with  defaults from defaults.yml ##}
 {% import_yaml 'packer/defaults.yml' as default_settings %}
 
 {##
-Setup variable using grains['os_family'] based logic, only add key:values here
-that differ from whats in defaults.yaml
+Setup variable using grains['os_family'] based logic
+os_family specific settings are stored in defaults.yml
 ##}
-{% set os_family_map = salt['grains.filter_by']({
-        'Debian': {},
-        'Suse': {},
-        'Arch': {},
-        'RedHat': {},
-  }
-  , grain="os_family"
-  , merge=salt['pillar.get']('packer:lookup'))
-%}
-{## Merge the flavor_map to the default settings ##}
-{% do default_settings.packer.update(os_family_map) %}
-
-{## Merge in packer:lookup pillar ##}
-{% set packer = salt['pillar.get'](
-        'packer',
-        default=default_settings.packer,
-        merge=True
-    )
+{% 
+    set packer = salt['grains.filter_by'](
+        default_settings,
+        base='default',
+        grain="os_family",
+        merge=salt['pillar.get']('packer:lookup')
+    ) 
 %}

--- a/pillar.example
+++ b/pillar.example
@@ -1,5 +1,4 @@
 packer:
-  lookup:
-    download:
-      version: '0.10.0'
-      hash: "sha256=7d51fc5db19d02bbf32278a8116830fae33a3f9bd4440a58d23ad7c863e92e28"
+  download:
+    version: '0.10.0'
+    hash: "sha256=7d51fc5db19d02bbf32278a8116830fae33a3f9bd4440a58d23ad7c863e92e28"

--- a/pillar.example
+++ b/pillar.example
@@ -1,4 +1,5 @@
 packer:
-  download:
-    version: '0.10.0'
-    hash: "sha256=7d51fc5db19d02bbf32278a8116830fae33a3f9bd4440a58d23ad7c863e92e28"
+  lookup:
+    download:
+      version: '0.10.0'
+      hash: "sha256=7d51fc5db19d02bbf32278a8116830fae33a3f9bd4440a58d23ad7c863e92e28"


### PR DESCRIPTION
The pillar.example file given results in an error during rendering.

```
[ERROR   ] Rendering exception occurred: Jinja variable 'salt.utils.odict.OrderedDict object' has no attribute 'url'
[CRITICAL] Rendering SLS 'base:packer.install' failed: Jinja variable 'salt.utils.odict.OrderedDict object' has no attribute 'url'
[ERROR   ] Data passed to highstate outputter is not a valid highstate return: {'local': ["Rendering SLS 'base:packer.install' failed: Jinja variable 'salt.utils.odict.OrderedDict object' has no attribute 'url'"]}
```

Removing the lookup key from my pillar file allows the states to render.
